### PR TITLE
Refactor Order model to use dynamic user currency instead of hardcode…

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -13,7 +13,8 @@
       "Bash(pip install docker)",
       "Bash(pip show flask werkzeug)",
       "Bash(grep -n \"from exceptions\\\\|from utils\\\\|import exceptions\\\\|import utils\" /Users/ralfeus/Projects/order/network_builder/network_manager/*.py)",
-      "Bash(xargs -r docker stop)"
+      "Bash(xargs -r docker stop)",
+      "/Users/ralfeus/.virtualenvs/order/bin/python -m pytest*"
     ]
   }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -31,6 +31,5 @@
     "python.defaultInterpreterPath": "python",
     "containers.imageBuildContextPath": ".",
     "python-envs.defaultEnvManager": "ms-python.python:system",
-    "python-envs.pythonProjects": [],
     "cursorpyright.analysis.typeCheckingMode": "basic"
 }

--- a/app/orders/models/order.py
+++ b/app/orders/models/order.py
@@ -84,14 +84,13 @@ class Order(db.Model, BaseModel): # type: ignore
     shipping_method_id = Column(Integer, ForeignKey('shipping.id'))
     shipping: Shipping = relationship('Shipping', foreign_keys=[shipping_method_id]) # type: ignore
     subtotal_krw = Column(Integer(), default=0)
-    subtotal_cur1 = Column(Numeric(10, 2), default=0)
-    subtotal_cur2 = Column(Numeric(10, 2), default=0)
+    subtotal_user_currency = Column(Numeric(10, 2), default=0)
     shipping_krw = Column(Integer(), default=0)
-    shipping_cur1 = Column(Numeric(10, 2), default=0)
-    shipping_cur2 = Column(Numeric(10, 2), default=0)
+    shipping_user_currency = Column(Numeric(10, 2), default=0)
     total_krw = Column(Integer(), default=0)
-    total_cur1 = Column(Numeric(10, 2), default=0)
-    total_cur2 = Column(Numeric(10, 2), default=0)
+    total_user_currency = Column(Numeric(10, 2), default=0)
+    currency_code = Column(String(3), ForeignKey('currencies.code'), nullable=True)
+    user_currency: Currency = relationship(Currency, foreign_keys=[currency_code])
     status = Column(Enum(OrderStatus), default='pending')
     tracking_id = Column(String(64))
     tracking_url:str = Column(String(256)) # type: ignore
@@ -290,32 +289,27 @@ class Order(db.Model, BaseModel): # type: ignore
     def get_service_fee(self, currency: Optional[Currency]=None):
         return (self.service_fee * currency.rate) if currency else self.service_fee
     
+    def _get_in_currency(self, base_amount, user_amount, currency: Optional[Currency]):
+        '''Returns amount in the requested currency.
+        Uses pre-computed user_amount if the currency matches order.currency_code,
+        otherwise converts from base (KRW) on the fly.'''
+        if not currency or currency.base:
+            return base_amount
+        if currency.code == self.currency_code and user_amount:
+            return user_amount
+        return round(base_amount * float(currency.rate), currency.decimal_places or 0)
+
     def get_shipping(self, currency: Optional[Currency]=None):
         ''' Returns shipping cost in currency provided '''
-        return \
-            self.shipping_cur1 if currency and currency.code == 'USD' \
-            else self.shipping_cur2 if currency and currency.code == 'EUR' \
-            else self.shipping_krw if currency and currency.base \
-            else round(self.shipping_krw * currency.rate, currency.decimal_places or 0) if currency \
-            else self.shipping_krw
+        return self._get_in_currency(self.shipping_krw, self.shipping_user_currency, currency)
 
     def get_subtotal(self, currency: Optional[Currency]=None):
         '''Returns subtotal of the order - sum of cost of all order products'''
-        return \
-            self.subtotal_cur1 if currency and currency.code == 'USD' \
-            else self.subtotal_cur2 if currency and currency.code == 'EUR' \
-            else self.subtotal_krw if currency and currency.base \
-            else round(self.subtotal_krw * currency.rate, currency.decimal_places or 0) if currency \
-            else self.subtotal_krw
+        return self._get_in_currency(self.subtotal_krw, self.subtotal_user_currency, currency)
 
     def get_total(self, currency: Optional[Currency]=None):
         '''Returns total of the order - subtotal plus shipping costs plus service fee'''
-        return \
-            self.total_cur1 if currency and currency.code == 'USD' \
-            else self.total_cur2 if currency and currency.code == 'EUR' \
-            else self.total_krw if currency and currency.base \
-            else round(self.total_krw * currency.rate, currency.decimal_places or 0) if currency \
-            else self.total_krw
+        return self._get_in_currency(self.total_krw, self.total_user_currency, currency)
 
     def get_total_points(self):
         return reduce(
@@ -358,16 +352,13 @@ class Order(db.Model, BaseModel): # type: ignore
             logger.debug("%s totals are undefined. Updating...", self.id)
             self.update_total()
             is_order_updated = True
-        if not self.total_cur1:
-            logger.debug("%s total USD is undefined. Updating...", self.id)
-            self.total_cur1 = self.total_krw * Currency.query.get('USD').rate
-            is_order_updated = True
-        if not self.total_cur2:
-            logger.debug("%s total EUR is undefined. Updating...", self.id)
-            curr_eur = Currency.query.get('EUR')
-            rate = curr_eur.rate if curr_eur is not None else 0
-            self.total_cur2 = self.total_krw * rate
-            is_order_updated = True
+        if not self.total_user_currency and self.currency_code:
+            logger.debug("%s total in user currency (%s) is undefined. Updating...",
+                         self.id, self.currency_code)
+            user_currency = Currency.query.get(self.currency_code)
+            if user_currency and not user_currency.base:
+                self.total_user_currency = self.total_krw * user_currency.rate
+                is_order_updated = True
         if is_order_updated:
             db.session.commit()
         check_outsiders_setting = Setting.query.get('check_outsiders')
@@ -406,8 +397,8 @@ class Order(db.Model, BaseModel): # type: ignore
             'shipping_krw': self.shipping_krw,
             'total': self.total_krw,
             'total_krw': self.total_krw,
-            'total_cur1': float(self.total_cur1),
-            'total_cur2': float(self.total_cur2),
+            'total_user_currency': float(self.total_user_currency) if self.total_user_currency else None,
+            'currency_code': self.currency_code,
             'shipping': self.shipping.to_dict() if self.shipping else None,
             'boxes': [box.to_dict() for box in self.boxes],
             'status': self.status.name if self.status else None,
@@ -493,23 +484,22 @@ class Order(db.Model, BaseModel): # type: ignore
         #                            self.order_products, 0)
         self.subtotal_krw = reduce(
             lambda acc, sub: acc + sub.get_subtotal() + sub.local_shipping, self.suborders, 0)
-        curr_eur = Currency.query.get('EUR')
-        rate_eur = curr_eur.rate if curr_eur is not None else 0
         logger.debug("Subtotal: %s", self.subtotal_krw)
-        self.subtotal_cur2 = self.subtotal_krw * float(rate_eur)
-        self.subtotal_cur1 = self.subtotal_krw * float(Currency.query.get('USD').rate)
+
+        user_currency = Currency.query.get(self.currency_code) if self.currency_code else None
+        user_rate = float(user_currency.rate) if user_currency and not user_currency.base else None
+
+        self.subtotal_user_currency = self.subtotal_krw * user_rate if user_rate is not None else 0
 
         self.shipping_krw = int(Decimal(self.shipping.get_shipping_cost(
             self.country.id if self.country else None,
             self.total_weight + self.shipping_box_weight)))
         logger.debug("Shipping (base): %s", self.shipping_krw)
-        self.shipping_cur2 = self.shipping_krw * float(rate_eur)
-        self.shipping_cur1 = self.shipping_krw * float(Currency.query.get('USD').rate)
+        self.shipping_user_currency = self.shipping_krw * user_rate if user_rate is not None else 0
         logger.debug("Service fee: %s", self.service_fee)
         self.total_krw = self.subtotal_krw + self.shipping_krw + self.service_fee
         logger.debug("Total (base): %s", self.total_krw)
-        self.total_cur2 = self.subtotal_cur2 + self.shipping_cur2
-        self.total_cur1 = self.subtotal_cur1 + self.shipping_cur1
+        self.total_user_currency = self.subtotal_user_currency + self.shipping_user_currency
 
 
     def get_order_excel(self) -> _TemporaryFileWrapper:

--- a/migrations/versions/b1c2d3e4f5a6_order_user_currency.py
+++ b/migrations/versions/b1c2d3e4f5a6_order_user_currency.py
@@ -1,0 +1,62 @@
+"""Add user currency to orders
+
+Replaces the hardcoded cur1 (USD) / cur2 (EUR) secondary currency columns
+with a single user-selected currency column and matching amount fields.
+
+Revision ID: b1c2d3e4f5a6
+Revises: a1743bf06a76
+Create Date: 2026-03-10 00:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import mysql
+
+# revision identifiers, used by Alembic.
+revision = 'b1c2d3e4f5a6'
+down_revision = '6cd4761bf604'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Add user-selected currency code column
+    op.add_column('orders', sa.Column('currency_code', sa.String(length=3), nullable=True))
+    op.create_foreign_key(
+        'fk_orders_currency_code', 'orders', 'currencies', ['currency_code'], ['code']
+    )
+
+    # Rename cur1 columns (previously hardcoded USD) to user_currency
+    op.alter_column('orders', 'subtotal_cur1',
+                    existing_type=mysql.NUMERIC(10, 2), new_column_name='subtotal_user_currency')
+    op.alter_column('orders', 'shipping_cur1',
+                    existing_type=mysql.NUMERIC(10, 2), new_column_name='shipping_user_currency')
+    op.alter_column('orders', 'total_cur1',
+                    existing_type=mysql.NUMERIC(10, 2), new_column_name='total_user_currency')
+
+    # Populate currency_code for existing orders (they were USD = cur1)
+    op.execute("UPDATE orders SET currency_code = 'USD' WHERE currency_code IS NULL")
+
+    # Drop the hardcoded cur2 (EUR) columns
+    op.drop_column('orders', 'subtotal_cur2')
+    op.drop_column('orders', 'shipping_cur2')
+    op.drop_column('orders', 'total_cur2')
+
+
+def downgrade():
+    # Restore cur2 columns (EUR)
+    op.add_column('orders', sa.Column('subtotal_cur2', mysql.NUMERIC(10, 2), nullable=True))
+    op.add_column('orders', sa.Column('shipping_cur2', mysql.NUMERIC(10, 2), nullable=True))
+    op.add_column('orders', sa.Column('total_cur2', mysql.NUMERIC(10, 2), nullable=True))
+
+    # Rename user_currency columns back to cur1
+    op.alter_column('orders', 'subtotal_user_currency',
+                    existing_type=mysql.NUMERIC(10, 2), new_column_name='subtotal_cur1')
+    op.alter_column('orders', 'shipping_user_currency',
+                    existing_type=mysql.NUMERIC(10, 2), new_column_name='shipping_cur1')
+    op.alter_column('orders', 'total_user_currency',
+                    existing_type=mysql.NUMERIC(10, 2), new_column_name='total_cur1')
+
+    # Drop currency_code column
+    op.drop_constraint('fk_orders_currency_code', 'orders', type_='foreignkey')
+    op.drop_column('orders', 'currency_code')

--- a/tests/orders/test_order_model.py
+++ b/tests/orders/test_order_model.py
@@ -1,0 +1,196 @@
+"""
+Tests for Order model currency methods (Subtask 1: DB Migration + Order Model Refactor)
+"""
+from tests import BaseTestCase, db
+from app.currencies.models import Currency
+from app.models.country import Country
+from app.orders.models.order import Order
+from app.orders.models.order_status import OrderStatus
+from app.orders.models.order_product import OrderProduct
+from app.orders.models.subcustomer import Subcustomer
+from app.orders.models.suborder import Suborder
+from app.products.models import Product
+from app.shipping.models.shipping import NoShipping, Shipping, ShippingRate
+from app.users.models.user import User
+
+
+class TestOrderModelCurrency(BaseTestCase):
+    def setUp(self):
+        super().setUp()
+        db.create_all()
+        self.base_currency = Currency(code='KRW', rate=1, base=True)
+        self.usd = Currency(code='USD', rate=0.001)   # 1 KRW = 0.001 USD
+        self.eur = Currency(code='EUR', rate=0.0009)  # 1 KRW = 0.0009 EUR
+        self.user = User(
+            username='test_order_model_user',
+            email='test_order_model@test.com',
+            password_hash='pbkdf2:sha256:150000$bwYY0rIO$320d11e791b3a0f1d0742038ceebf879b8182898cbefee7bf0e55b9c9e9e5576',
+            enabled=True,
+        )
+        self.country = Country(id='KR', name='South Korea')
+        self.no_shipping = NoShipping(id=999)
+        self.try_add_entities([
+            self.base_currency, self.usd, self.eur,
+            self.user, self.country, self.no_shipping,
+        ])
+
+    def _make_order(self, currency_code='USD', total_krw=100000,
+                    total_user_currency=100.0, shipping_krw=10000,
+                    shipping_user_currency=10.0, subtotal_krw=90000,
+                    subtotal_user_currency=90.0):
+        """Helper to create an order with preset currency amounts."""
+        order = Order(user=self.user, status=OrderStatus.pending)
+        order.currency_code = currency_code
+        order.total_krw = total_krw
+        order.total_user_currency = total_user_currency
+        order.shipping_krw = shipping_krw
+        order.shipping_user_currency = shipping_user_currency
+        order.subtotal_krw = subtotal_krw
+        order.subtotal_user_currency = subtotal_user_currency
+        self.try_add_entity(order)
+        return order
+
+    # --- get_total() tests ---
+
+    def test_get_total_no_currency_returns_krw(self):
+        """get_total() with no argument returns base (KRW) amount."""
+        order = self._make_order(total_krw=100000, total_user_currency=100.0)
+        self.assertEqual(order.get_total(), 100000)
+
+    def test_get_total_base_currency_returns_krw(self):
+        """get_total(base_currency) returns base (KRW) amount."""
+        order = self._make_order(total_krw=100000, total_user_currency=100.0)
+        self.assertEqual(order.get_total(self.base_currency), 100000)
+
+    def test_get_total_matching_user_currency_returns_precomputed(self):
+        """get_total() with currency matching order.currency_code returns stored amount."""
+        order = self._make_order(currency_code='USD', total_krw=100000, total_user_currency=100.0)
+        result = order.get_total(self.usd)
+        self.assertEqual(result, 100.0)
+
+    def test_get_total_arbitrary_currency_converts_from_krw(self):
+        """get_total() with a currency different from order.currency_code converts on the fly."""
+        order = self._make_order(currency_code='USD', total_krw=100000, total_user_currency=100.0)
+        # EUR rate = 0.0009, so 100000 * 0.0009 = 90.0
+        result = order.get_total(self.eur)
+        self.assertAlmostEqual(float(result), 90.0, places=2)
+
+    def test_get_total_none_user_currency_falls_back_to_conversion(self):
+        """get_total() when stored user_currency amount is 0/None uses conversion."""
+        order = self._make_order(currency_code='USD', total_krw=100000, total_user_currency=0)
+        result = order.get_total(self.usd)
+        # Falls back to conversion: 100000 * 0.001 = 100.0
+        self.assertAlmostEqual(float(result), 100.0, places=2)
+
+    # --- get_shipping() tests ---
+
+    def test_get_shipping_no_currency_returns_krw(self):
+        order = self._make_order(shipping_krw=10000, shipping_user_currency=10.0)
+        self.assertEqual(order.get_shipping(), 10000)
+
+    def test_get_shipping_base_currency_returns_krw(self):
+        order = self._make_order(shipping_krw=10000, shipping_user_currency=10.0)
+        self.assertEqual(order.get_shipping(self.base_currency), 10000)
+
+    def test_get_shipping_user_currency_returns_precomputed(self):
+        order = self._make_order(currency_code='USD', shipping_krw=10000, shipping_user_currency=10.0)
+        self.assertEqual(order.get_shipping(self.usd), 10.0)
+
+    def test_get_shipping_arbitrary_currency_converts(self):
+        order = self._make_order(currency_code='USD', shipping_krw=10000, shipping_user_currency=10.0)
+        result = order.get_shipping(self.eur)
+        self.assertAlmostEqual(float(result), 9.0, places=2)
+
+    # --- get_subtotal() tests ---
+
+    def test_get_subtotal_no_currency_returns_krw(self):
+        order = self._make_order(subtotal_krw=90000, subtotal_user_currency=90.0)
+        self.assertEqual(order.get_subtotal(), 90000)
+
+    def test_get_subtotal_base_currency_returns_krw(self):
+        order = self._make_order(subtotal_krw=90000, subtotal_user_currency=90.0)
+        self.assertEqual(order.get_subtotal(self.base_currency), 90000)
+
+    def test_get_subtotal_user_currency_returns_precomputed(self):
+        order = self._make_order(currency_code='USD', subtotal_krw=90000, subtotal_user_currency=90.0)
+        self.assertEqual(order.get_subtotal(self.usd), 90.0)
+
+    def test_get_subtotal_arbitrary_currency_converts(self):
+        order = self._make_order(currency_code='USD', subtotal_krw=90000, subtotal_user_currency=90.0)
+        result = order.get_subtotal(self.eur)
+        self.assertAlmostEqual(float(result), 81.0, places=2)
+
+    # --- to_dict() tests ---
+
+    def test_to_dict_includes_currency_code(self):
+        """to_dict() must include currency_code field."""
+        order = self._make_order(currency_code='USD', total_krw=100000, total_user_currency=100.0)
+        result = order.to_dict()
+        self.assertIn('currency_code', result)
+        self.assertEqual(result['currency_code'], 'USD')
+
+    def test_to_dict_includes_total_user_currency(self):
+        """to_dict() must include total_user_currency instead of total_cur1/total_cur2."""
+        order = self._make_order(currency_code='USD', total_krw=100000, total_user_currency=100.0)
+        result = order.to_dict()
+        self.assertIn('total_user_currency', result)
+        self.assertAlmostEqual(result['total_user_currency'], 100.0, places=2)
+
+    def test_to_dict_does_not_include_hardcoded_cur1_cur2(self):
+        """to_dict() must not contain the old hardcoded total_cur1 / total_cur2 keys."""
+        order = self._make_order(currency_code='USD', total_krw=100000, total_user_currency=100.0)
+        result = order.to_dict()
+        self.assertNotIn('total_cur1', result)
+        self.assertNotIn('total_cur2', result)
+
+    # --- update_total() tests ---
+
+    def test_update_total_stores_user_currency_amounts(self):
+        """update_total() computes user_currency amounts using order.currency_code rate."""
+        product = Product(id='T001', name='Test', price=10000, weight=100)
+        self.try_add_entity(product)
+        order = Order(user=self.user, status=OrderStatus.pending)
+        order.currency_code = 'USD'
+        order.country = self.country
+        order.shipping = self.no_shipping
+        self.try_add_entity(order)
+        suborder = Suborder(order=order)
+        self.try_add_entity(suborder)
+        op = OrderProduct(suborder=suborder, product_id='T001', quantity=2)
+        self.try_add_entity(op)
+
+        order.update_total()
+
+        # subtotal = 10000 * 2 = 20000 KRW + 2500 local shipping (below threshold) = 22500
+        self.assertEqual(order.subtotal_krw, 22500)
+        # subtotal_user_currency = 22500 * 0.001 = 22.5 USD
+        self.assertAlmostEqual(float(order.subtotal_user_currency), 22.5, places=2)
+        # NoShipping has no cost, so shipping = 0
+        self.assertEqual(order.shipping_krw, 0)
+        self.assertEqual(float(order.shipping_user_currency), 0.0)
+        # total_krw = 22500
+        self.assertEqual(order.total_krw, 22500)
+        # total_user_currency = 22.5
+        self.assertAlmostEqual(float(order.total_user_currency), 22.5, places=2)
+
+    def test_update_total_base_currency_sets_zero_user_amounts(self):
+        """update_total() when currency_code is base (KRW), user_currency amounts are 0."""
+        product = Product(id='T002', name='Test2', price=10000, weight=100)
+        self.try_add_entity(product)
+        order = Order(user=self.user, status=OrderStatus.pending)
+        order.currency_code = 'KRW'
+        order.country = self.country
+        order.shipping = self.no_shipping
+        self.try_add_entity(order)
+        suborder = Suborder(order=order)
+        self.try_add_entity(suborder)
+        op = OrderProduct(suborder=suborder, product_id='T002', quantity=1)
+        self.try_add_entity(op)
+
+        order.update_total()
+
+        # subtotal = 10000 + 2500 local shipping (below 30000 threshold) = 12500
+        self.assertEqual(order.subtotal_krw, 12500)
+        # Base currency — user_currency amounts should be 0 (no conversion needed)
+        self.assertEqual(float(order.subtotal_user_currency), 0.0)
+        self.assertEqual(float(order.total_user_currency), 0.0)

--- a/tests/orders/test_orders_api.py
+++ b/tests/orders/test_orders_api.py
@@ -754,7 +754,7 @@ class TestOrdersApi(BaseTestCase):
 
     def test_get_order(self):
         gen_id = f"{__name__}-{int(datetime.now().timestamp())}"
-        order = Order(id=gen_id, user=self.user)
+        order = Order(id=gen_id, user=self.user, currency_code='USD')
         suborder = Suborder(order=order)
         self.try_add_entities([Product(id=gen_id, price=10, weight=10)])
         self.try_add_entities(
@@ -771,8 +771,11 @@ class TestOrdersApi(BaseTestCase):
             lambda: self.client.get(f"/api/v1/order/{gen_id}")
         )
         self.assertEqual(res.json["total"], 2600)
-        self.assertEqual(res.json["total_cur2"], 1300.0)
-        self.assertEqual(res.json["total_cur1"], 1300.0)
+        # total_user_currency is the user-selected currency amount (USD, rate=0.5)
+        self.assertAlmostEqual(res.json["total_user_currency"], 1300.0, places=2)
+        self.assertEqual(res.json["currency_code"], 'USD')
+        self.assertNotIn("total_cur1", res.json)
+        self.assertNotIn("total_cur2", res.json)
         self.assertEqual(res.json["user"], self.user.username)
         self.assertEqual(len(res.json["order_products"]), 1)
         res = self.client.get("/api/v1/order")


### PR DESCRIPTION
…d USD/EUR

- Replace hardcoded subtotal_cur1/cur2, shipping_cur1/cur2, total_cur1/cur2 columns with generic subtotal_user_currency, shipping_user_currency, total_user_currency and a currency_code FK column
- Add _get_in_currency() helper for clean currency conversion logic
- Update get_total/get_shipping/get_subtotal to use new helper
- Update update_total() to compute user-currency amounts dynamically
- Update to_dict() to return currency_code and total_user_currency
- Add Alembic migration b1c2d3e4f5a6 that renames/drops old columns and backfills currency_code='USD' for existing orders
- Add 18 unit tests for currency conversion scenarios (test_order_model.py)
- Update test_orders_api.py to match new field names